### PR TITLE
Fixed invalid JSON preventing cam material from loading.

### DIFF
--- a/Models/Cam/Cam_lambert3.material
+++ b/Models/Cam/Cam_lambert3.material
@@ -22,7 +22,7 @@
             ]
         },
         "normal": {
-            "textureMap": "Models/Cam/Cat Burglar_Cat_Normal.jpg",
+            "textureMap": "Models/Cam/Cat Burglar_Cat_Normal.jpg"
         },
         "opacity": {
             "factor": 1.0


### PR DESCRIPTION
The cam material had invalid JSON (an extra comma on a line), which was preventing from the material from being loaded.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>