### PR TITLE
Fixed several cmake issues with the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,18 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
 
 if(NOT PROJECT_NAME)
     cmake_minimum_required(VERSION 3.20)
+    include(cmake/EngineFinder.cmake OPTIONAL)
+    find_package(o3de REQUIRED)
     project(GentlecatThief
         LANGUAGES C CXX
         VERSION 1.0.0.0
     )
-    include(EngineFinder.cmake OPTIONAL)
-    find_package(o3de REQUIRED)
     o3de_initialize()
-else()
-    # Add the project_name to global LY_PROJECTS_TARGET_NAME property
-    file(READ "${CMAKE_CURRENT_LIST_DIR}/project.json" project_json)
-
-    string(JSON project_target_name ERROR_VARIABLE json_error GET ${project_json} "project_name")
-    if(json_error)
-        message(FATAL_ERROR "Unable to read key 'project_name' from 'project.json'")
-    endif()
-
-    set_property(GLOBAL APPEND PROPERTY LY_PROJECTS_TARGET_NAME ${project_target_name})
-
-    add_subdirectory(Gem)
 endif()

--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -12,7 +12,7 @@
 #       in which case it will see if that platform is present here or in the restricted folder.
 #       i.e. It could here : GentlecatThief/Code/Platform/<platform_name>  or
 #            <restricted_folder>/<platform_name>/GentlecatThief/Code
-o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} ${gem_restricted_path} ${gem_path} ${gem_parent_relative_path})
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
 # Now that we have the platform abstraction layer (PAL) folder for this folder, thats where we will find the
 # traits for this platform. Traits for a platform are defines for things like whether or not something in this project

--- a/cmake/EngineFinder.cmake
+++ b/cmake/EngineFinder.cmake
@@ -1,0 +1,90 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+# This file is copied during engine registration. Edits to this file will be lost next
+# time a registration happens.
+
+include_guard()
+
+# Read the engine name from the project_json file
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/project.json project_json)
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/project.json)
+
+string(JSON LY_ENGINE_NAME_TO_USE ERROR_VARIABLE json_error GET ${project_json} engine)
+if(json_error)
+    message(FATAL_ERROR "Unable to read key 'engine' from 'project.json'\nError: ${json_error}")
+endif()
+
+if(CMAKE_MODULE_PATH)
+    foreach(module_path ${CMAKE_MODULE_PATH})
+        if(EXISTS ${module_path}/Findo3de.cmake)
+            file(READ ${module_path}/../engine.json engine_json)
+            string(JSON engine_name ERROR_VARIABLE json_error GET ${engine_json} engine_name)
+            if(json_error)
+                message(FATAL_ERROR "Unable to read key 'engine_name' from 'engine.json'\nError: ${json_error}")
+            endif()
+            if(LY_ENGINE_NAME_TO_USE STREQUAL engine_name)
+                return() # Engine being forced through CMAKE_MODULE_PATH
+            endif()
+        endif()
+    endforeach()
+endif()
+
+if(DEFINED ENV{USERPROFILE} AND EXISTS $ENV{USERPROFILE})
+    set(manifest_path $ENV{USERPROFILE}/.o3de/o3de_manifest.json) # Windows
+else()
+    set(manifest_path $ENV{HOME}/.o3de/o3de_manifest.json) # Unix
+endif()
+
+set(registration_error [=[
+Engine registration is required before configuring a project.
+Run 'scripts/o3de register --this-engine' from the engine root.
+]=])
+
+# Read the ~/.o3de/o3de_manifest.json file and look through the 'engines_path' object.
+# Find a key that matches LY_ENGINE_NAME_TO_USE and use that as the engine path.
+if(EXISTS ${manifest_path})
+    file(READ ${manifest_path} manifest_json)
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${manifest_path})
+
+    string(JSON engines_path_count ERROR_VARIABLE json_error LENGTH ${manifest_json} engines_path)
+    if(json_error)
+        message(FATAL_ERROR "Unable to read key 'engines_path' from '${manifest_path}'\nError: ${json_error}\n${registration_error}")
+    endif()
+
+    string(JSON engines_path_type ERROR_VARIABLE json_error TYPE ${manifest_json} engines_path)
+    if(json_error OR NOT ${engines_path_type} STREQUAL "OBJECT")
+        message(FATAL_ERROR "Type of 'engines_path' in '${manifest_path}' is not a JSON Object\nError: ${json_error}")
+    endif()
+
+    math(EXPR engines_path_count "${engines_path_count}-1")
+    foreach(engine_path_index RANGE ${engines_path_count})
+        string(JSON engine_name ERROR_VARIABLE json_error MEMBER ${manifest_json} engines_path ${engine_path_index})
+        if(json_error)
+            message(FATAL_ERROR "Unable to read 'engines_path/${engine_path_index}' from '${manifest_path}'\nError: ${json_error}")
+        endif()
+
+        if(LY_ENGINE_NAME_TO_USE STREQUAL engine_name)
+            string(JSON engine_path ERROR_VARIABLE json_error GET ${manifest_json} engines_path ${engine_name})
+            if(json_error)
+                message(FATAL_ERROR "Unable to read value from 'engines_path/${engine_name}'\nError: ${json_error}")
+            endif()
+
+            if(engine_path)
+                list(APPEND CMAKE_MODULE_PATH "${engine_path}/cmake")
+                return()
+            endif()
+        endif()
+    endforeach()
+    
+    message(FATAL_ERROR "The project.json uses engine name '${LY_ENGINE_NAME_TO_USE}' but no engine with that name has been registered.\n${registration_error}")
+else()
+    # If the user is passing CMAKE_MODULE_PATH we assume thats where we will find the engine
+    if(NOT CMAKE_MODULE_PATH)
+        message(FATAL_ERROR "O3DE Manifest file not found.\n${registration_error}")
+    endif()
+endif()

--- a/project.json
+++ b/project.json
@@ -1,9 +1,10 @@
 {
     "project_name": "GentlecatThief",
-    "origin": "The primary repo for GentlecatThief goes here: i.e. http://www.mydomain.com",
+    "project_id": "{27bcebe5-fb36-49ec-beb6-ec24bf7b337f}",
+    "origin": "https://github.com/o3de/ChatCambrioleur",
     "license": "What license GentlecatThief uses goes here: i.e. https://opensource.org/licenses/MIT",
     "display_name": "GentlecatThief",
-    "summary": "A short description of GentlecatThief.",
+    "summary": "Chat Cambrioleur is an O3DE game jam project that was created to create a puzzle-like adventure for our feline friend.",
     "canonical_tags": [
         "Project"
     ],
@@ -12,6 +13,7 @@
     ],
     "icon_path": "preview.png",
     "engine": "o3de",
-    "external_subdirectories": [],
-    "project_id": "{27bcebe5-fb36-49ec-beb6-ec24bf7b337f}"
+    "external_subdirectories": [
+        "Gem"
+    ]
 }


### PR DESCRIPTION
Fixed several cmake issues with the project:
- Updated `project.json` to match the template's `external_subdirectories`, as well as updated the description and origin link
- Fixed the project root `CMakeLists.txt`
- Added missing `cmake/EngineFinder.cmake`
- Fixed `o3de_pal_dir` API usage issue in `Gem/Code/CMakeLists.txt`

NOTE: This gets the project building and you can create a new level fine, but loading the `EgyptianLevel` (which holds the game level) currently crashes with some missing asset references. Will need to fix that in a follow-up PR.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>